### PR TITLE
프론트 도메인만 허용

### DIFF
--- a/src/main/java/com/team/grade_checklist/security/SecurityConfig.java
+++ b/src/main/java/com/team/grade_checklist/security/SecurityConfig.java
@@ -60,12 +60,12 @@ public class SecurityConfig {
         // 현재는 모든 도메인 허용
         if (isProduction()) {
             // 운영환경에서는 실제 프론트엔드 도메인만 허용할 것
-            // configuration.setAllowedOrigins(Arrays.asList(
-            //     "https://frontend-domain.com",
-            //     "https://www.frontend-domain.com"
-            // ));
+             configuration.setAllowedOrigins(Arrays.asList(
+                 "https://api.graduation-check.wink.io.kr",
+                 "https://localhost:3000"
+             ));
 
-            configuration.setAllowedOriginPatterns(Arrays.asList("*")); // -> 지워야됨
+            //configuration.setAllowedOriginPatterns(Arrays.asList("*")); // -> 지워야됨
         } else {
             // 개발환경 -> 로컬 개발서버 허용
             configuration.setAllowedOriginPatterns(Arrays.asList("*"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프로덕션에서 접근 허용 도메인을 명시적으로 제한하여 연결 안정성을 향상했습니다. 허용 도메인: https://api.graduation-check.wink.io.kr, https://localhost:3000
  * 와일드카드(*) 오리진 허용을 제거하여 예기치 않은 외부 접근을 차단했습니다.

* **Chores**
  * 개발 환경은 기존과 동일하게 모든 오리진을 허용하도록 설정을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->